### PR TITLE
Show sum of all CPU cores in the menu bar

### DIFF
--- a/Modules/CPU/readers.swift
+++ b/Modules/CPU/readers.swift
@@ -145,6 +145,7 @@ internal class LoadReader: Reader<CPU_Load> {
             
             self.response.usageECores = eCoresList.reduce(0, +)/Double(eCoresList.count)
             self.response.usagePCores = pCoresList.reduce(0, +)/Double(pCoresList.count)
+            self.response.totalUsage = eCoresList.reduce(0, +) + pCoresList.reduce(0, +)
         }
         
         self.callback(self.response)


### PR DESCRIPTION
What it does

- it shows the sum of all the CPU usages. For example if there's a process that uses one cpu core then it will show about 110% cpu usage, if 5 cpu cores are used, then it will show about 500% cpu usage.

What it does not do

- it does not adjust the size of the menu bar item, so the percentage character is partially cut off when the cpu usage is more than 100%.
- i did not test the cpu chart, that's probably totally broken.
- there's no user preferences, it always shows the sum of the cpu usage.